### PR TITLE
postgresql db supported

### DIFF
--- a/components/BlogTagSearch.php
+++ b/components/BlogTagSearch.php
@@ -1,5 +1,6 @@
 <?php namespace Bedard\BlogTags\Components;
 
+use Cms\Classes\Page;
 use Bedard\BlogTags\Models\Tag;
 use Cms\Classes\ComponentBase;
 use Rainlab\Blog\Models\Post;
@@ -52,6 +53,12 @@ class BlogTagSearch extends ComponentBase
      */
     public $lastPage;
 
+     /**
+     * Reference to the page name for linking to posts.
+     * @var string
+     */
+    public $postPage;
+
 
     /**
      * Component Registration
@@ -97,6 +104,13 @@ class BlogTagSearch extends ComponentBase
                 'type'          => 'string',
                 'validationPattern' => '^(0+)?[1-9]\d*$',
                 'validationMessage' => 'Results per page must be a positive whole number.'
+            ],
+            'postPage' => [
+                'title'       => 'Post page',
+                'description' => 'Page to show linked posts',
+                'type'        => 'dropdown',
+                'default'     => 'blog/post',
+                'group'       => 'Links',
             ]
         ];
     }
@@ -131,10 +145,25 @@ class BlogTagSearch extends ComponentBase
         // Store the posts in a better container
         $this->posts = $this->tag->posts;
 
+        /*
+         * Add a "url" helper attribute for linking to each post
+        */
+        $this->posts->each(function($post)
+        {
+           $post->setUrl($this->postPage,$this->controller);
+        });
+
+
         // Count the posts being returned
         $this->postsOnPage = $this->tag
             ? count($this->tag->posts)
             : 0;
+    }
+
+
+    public function getPostPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
     }
 
     /**

--- a/components/BlogTagSearch.php
+++ b/components/BlogTagSearch.php
@@ -129,12 +129,13 @@ class BlogTagSearch extends ComponentBase
             ->first();
 
         // Store the posts in a better container
-        $this->posts = $this->tag->posts;
-
-        // Count the posts being returned
-        $this->postsOnPage = $this->tag
-            ? count($this->tag->posts)
-            : 0;
+        if(empty($this->tag)) {
+            $this->posts = null;
+            $this->postsOnPage = 0;
+        } else {
+            $this->posts = $this->tag->posts;
+            $this->postsOnPage = count($this->posts);
+        }
     }
 
     /**
@@ -151,7 +152,7 @@ class BlogTagSearch extends ComponentBase
         // Calculate the results per page
         $this->resultsPerPage = $this->property('pagination')
             ? intval($this->property('resultsPerPage'))
-            : $this->totalPosts;
+            : max(1, $this->totalPosts);
 
         // Calculate the last page
         $this->lastPage = ceil($this->totalPosts / $this->resultsPerPage);

--- a/components/BlogTagSearch.php
+++ b/components/BlogTagSearch.php
@@ -59,6 +59,11 @@ class BlogTagSearch extends ComponentBase
      */
     public $postPage;
 
+    /**
+     * @var string Reference to the page name for linking to categories.
+     */
+    public $categoryPage;
+
 
     /**
      * Component Registration
@@ -111,6 +116,13 @@ class BlogTagSearch extends ComponentBase
                 'type'        => 'dropdown',
                 'default'     => 'blog/post',
                 'group'       => 'Links',
+            ],
+            'categoryPage' => [
+                'title'       => 'rainlab.blog::lang.settings.posts_category',
+                'description' => 'rainlab.blog::lang.settings.posts_category_description',
+                'type'        => 'dropdown',
+                'default'     => 'blog/category',
+                'group'       => 'Links',
             ]
         ];
     }
@@ -120,6 +132,9 @@ class BlogTagSearch extends ComponentBase
      */
     public function onRun()
     {
+        $this->postPage = $this->page['postPage'] = $this->property('postPage');
+        $this->categoryPage = $this->page['categoryPage'] = $this->property('categoryPage');
+
         $this->onLoadPage($this->property('page'));
     }
 
@@ -153,12 +168,23 @@ class BlogTagSearch extends ComponentBase
             // Add a "url" helper attribute for linking to each post
             $this->posts->each(function($post) {
                 $post->setUrl($this->postPage,$this->controller);
+
+                if($post->categories->count()) {
+                    $post->categories->each(function($category){
+                        $category->setUrl($this->categoryPage, $this->controller);
+                    });
+                }
             });
         }
     }
 
 
     public function getPostPageOptions()
+    {
+        return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
+    }
+
+    public function getCategoryPageOptions()
     {
         return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
     }

--- a/components/BlogTags.php
+++ b/components/BlogTags.php
@@ -90,8 +90,8 @@ class BlogTags extends ComponentBase
         // Sort the tags
         $subQuery = DB::raw('(
             select count(*)
-            from `bedard_blogtags_post_tag`
-            where `bedard_blogtags_post_tag`.`tag_id` = `bedard_blogtags_tags`.`id`
+            from bedard_blogtags_post_tag
+            where bedard_blogtags_post_tag.tag_id = bedard_blogtags_tags.id
         )');
         $key = $this->property('orderBy') ?: $subQuery;
         $query->orderBy($key, $this->property('direction'));

--- a/components/blogrelated/default.htm
+++ b/components/blogrelated/default.htm
@@ -1,6 +1,6 @@
 <h1>Related posts</h1>
 <ul>
     {% for Post in __SELF__.posts %}
-        <li>{{ Post.title }}</li>
+        <a href="{{Post.url}}"><li>{{ Post.title }}</li></a>
     {% endfor %}
 </ul>

--- a/components/blogtagsearch/default.htm
+++ b/components/blogtagsearch/default.htm
@@ -1,6 +1,6 @@
 <h1>Search results for "{{ __SELF__.tag.name }}"</h1>
 <ul>
     {% for Post in __SELF__.tag.posts %}
-        <li>{{ Post.title }}</li>
+         <a href="{{Post.url}}"><li>{{ Post.title }}</li></a>
     {% endfor %}
 </ul>

--- a/components/blogtagsearch/default.htm
+++ b/components/blogtagsearch/default.htm
@@ -1,6 +1,12 @@
-<h1>Search results for "{{ __SELF__.tag.name }}"</h1>
+<h1>Search results for "{{ __SELF__.properties.tag }}"</h1>
+
+{% if __SELF__.posts %}
 <ul>
-    {% for Post in __SELF__.tag.posts %}
+    {% for Post in __SELF__.posts %}
         <li>{{ Post.title }}</li>
     {% endfor %}
 </ul>
+
+{% else %}
+No posts found.
+{%endif%}

--- a/components/blogtagsearch/default.htm
+++ b/components/blogtagsearch/default.htm
@@ -1,14 +1,19 @@
-<h1>Search results for "{{ __SELF__.properties.tag }}"</h1>
+<h1>Search results for "{{ __SELF__.tag.name }}"</h1>
 
 {% if __SELF__.posts %}
-<ul>
-
-    {% for Post in __SELF__.tag.posts %}
-    {{php_var_dump(Post)}}
-         <a href="{{Post.url}}"><li>{{ Post.title }}</li></a>
-    {% endfor %}
-</ul>
-
+    <ul>
+        {% for Post in __SELF__.tag.posts %}
+             <li>
+                 <a href="{{Post.url}}">{{ Post.title }}</a>
+                 {% if Post.categories %}
+                 - published in
+                    {% for category in Post.categories %}
+                        <a href="{{category.url|e}}">{{category.name}}</a>{% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                 {% endif %}
+             </li>
+        {% endfor %}
+    </ul>
 {% else %}
-No posts found.
+    No posts found.
 {%endif%}

--- a/models/Tag.php
+++ b/models/Tag.php
@@ -52,4 +52,18 @@ class Tag extends Model
         $this->attributes['name'] = strtolower($value);
     }
 
+     /**
+     * Sets the "url" attribute with a URL to this object
+     * @param string $pageName
+     * @param Cms\Classes\Controller $controller
+     */
+    public function setUrl($pageName, $controller)
+    {
+        $params = [
+            'id' => $this->id,
+            'slug' => $this->slug,
+        ];
+       
+        return $this->url = $controller->pageUrl($pageName, $params);
+    }
 }

--- a/models/tag/columns.yaml
+++ b/models/tag/columns.yaml
@@ -12,8 +12,8 @@ columns:
         select: >
             (
                 select count(*)
-                from `bedard_blogtags_post_tag`
-                where `bedard_blogtags_post_tag`.`tag_id` = `bedard_blogtags_tags`.`id`
+                from bedard_blogtags_post_tag
+                where bedard_blogtags_post_tag.tag_id = bedard_blogtags_tags.id
             )
 
     created_at:

--- a/readme.md
+++ b/readme.md
@@ -30,5 +30,7 @@ The `blogTagSearch` component returns all posts with a particular tag.
 - **Paginate results** - Determines if the results are paginated or not.
 - **Page** - The URL parameter defining the page number.
 - **Results** - Number of posts to display per page.
+- **Blog post page** - Link to page, where blog post to be displayed.
+
 
 This component also provides several pagination variables. They are ```totalPosts```, ```postsOnPage```, ```currentPage```, ```resultsPerPage```, ```previousPage```, ```nextPage```, and ```lastPage```. For an example of how to paginate your results, please review the pagination partial. The posts may be loaded through the ```Page``` URL parameter, or through the AJAX framework via the ```onLoadPage()``` method.

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ The `blogRelated` component can be used to display a post's related articles.
 - **Results** - The number of related posts to display.
 - **Sort by** - How to sort the related articles (by relevance, title, published date, or updated date).
 - **Order** - Direction to sort the results (ascending or descending).
+- **Blog post page** - Link to page, where blog post to be displayed.
 
 #### Tag List
 The `blogTags` component is can be used to display a list of all tags.

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ The `blogRelated` component can be used to display a post's related articles.
 - **Sort by** - How to sort the related articles (by relevance, title, published date, or updated date).
 - **Order** - Direction to sort the results (ascending or descending).
 - **Blog post page** - Link to page, where blog post to be displayed.
+- **Blog post categories** - Links to pages, where blog post categories to be displayed.
 
 #### Tag List
 The `blogTags` component is can be used to display a list of all tags.

--- a/updates/create_tags_table.php
+++ b/updates/create_tags_table.php
@@ -3,17 +3,23 @@
 use October\Rain\Database\Updates\Migration;
 use Schema;
 use System\Classes\PluginManager;
+use Illuminate\Support\Facades\DB;
 
 class CreateTagsTable extends Migration
 {
+
+    private $dbType;
 
     public function up()
     {
         if(PluginManager::instance()->hasPlugin('RainLab.Blog'))
         {
+            $this->dbType = DB::connection()->getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME);
+
             Schema::create('bedard_blogtags_tags', function($table)
             {
-                $table->engine = 'InnoDB';
+                $this->dbSpecificSetup($table);
+
                 $table->increments('id');
                 $table->string('name')->unique()->nullable();
                 $table->timestamps();
@@ -21,7 +27,8 @@ class CreateTagsTable extends Migration
 
             Schema::create('bedard_blogtags_post_tag', function($table)
             {
-                $table->engine = 'InnoDB';
+                $this->dbSpecificSetup($table);
+
                 $table->integer('tag_id')->unsigned()->nullable()->default(null);
                 $table->integer('post_id')->unsigned()->nullable()->default(null);
                 $table->index(['tag_id', 'post_id']);
@@ -39,5 +46,22 @@ class CreateTagsTable extends Migration
             Schema::dropIfExists('bedard_blogtags_tags');
         }
     }
+
+
+    /**
+     * @param $table
+     */
+    private function dbSpecificSetup(&$table)
+    {
+        switch ($this->dbType) {
+            case 'pgsql':
+                break;
+            case 'mysql':
+                //@todo SET sql_mode='ANSI_QUOTES';
+                $table->engine = 'InnoDB';
+                break;
+        }
+    }
+
 
 }


### PR DESCRIPTION
"InnoDB" is mySql specific, so it is used and executed only when mySql is used. 

MySQL uses ` (accent mark or backtick) to quote system identifiers, which is decidedly non-standard. There are two options to get around this. First one is to use mysql query that sets mysql usage to standard ANSI
`SET sql_mode='ANSI_QUOTES';`

However with ANSI_QUOTES enabled, you cannot use double quotation marks to quote literal strings, because it is interpreted as an identifier.

More about this [here](https://wiki.postgresql.org/wiki/Things_to_find_out_about_when_moving_from_MySQL_to_PostgreSQL) and [here](https://dev.mysql.com/doc/refman/5.6/en/sql-mode.html#sqlmode_ansi_quotes). 

Workaround that works on postgresql and should work on mysql just fine is to remove quotes altogether as I did. The only situation where quoting all identifiers is required is either using reserved words (which this extension doesn't) or when you generate SQL programmatically.

**Haven't tested changes on mysql, so please before merging into production test that it doesnt break mysql!**
