### PR TITLE
bug fix in calculatePagination

### DIFF
--- a/components/BlogTagSearch.php
+++ b/components/BlogTagSearch.php
@@ -197,7 +197,8 @@ class BlogTagSearch extends ComponentBase
     {
         // Count the number of posts with this tag
         $this->totalPosts = Post::whereHas('tags', function($tag) {
-                $tag->where('name', $this->property('tag'));
+                $tag->where('name', $this->property('tag'))
+                    ->orWhere('slug', $this->property('tag');
             })
             ->count();
 


### PR DESCRIPTION
tag slug was excluded from the posts query and was not consistent with `onLoadPage` post query.